### PR TITLE
fix code hightlight bug

### DIFF
--- a/render.go
+++ b/render.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+    "regexp"
 )
 
 type RenderFactory struct{}
@@ -282,8 +283,8 @@ func (self *RenderFactory) RenderPosts(root string, yamls map[string]interface{}
 			htmlByte := blackfriday.MarkdownCommon([]byte(mardownStr))
 			//init other article infos
 			htmlStr := html.UnescapeString(string(htmlByte))
-			htmlStr = strings.Replace(htmlStr, "<pre><code", `<pre class="prettyprint linenums"`, -1)
-			htmlStr = strings.Replace(htmlStr, `</code>`, "", -1)
+            re := regexp.MustCompile(`<pre><code>([\s\S]*?)</code></pre>`)
+            htmlStr = re.ReplaceAllString(htmlStr, `<pre class="prettyprint linenums">${1}</pre>`)
 			fi.Content = htmlStr
 			fi.Link = p + trName + ".html"
 			//if abstract is empty,auto gen it

--- a/strutil.go
+++ b/strutil.go
@@ -9,7 +9,7 @@ func trimHTML(str string) string {
 	if str == "" {
 		return str
 	}
-	re, _ := regexp.Compile(`\<*+?(\>|$)`)
+	re, _ := regexp.Compile(`<[\s\S]+?(>|$)`)
 	newstr := re.ReplaceAllString(str, "")
 	return newstr
 }


### PR DESCRIPTION
fix a bug which may result in no closing tags when insert short code.

for example, we use ` insert short some code in markdown and then the tag </code> will be removed in old version. 
